### PR TITLE
Add example of image registration/alignment

### DIFF
--- a/image_registration/tweakwcs_example.ipynb
+++ b/image_registration/tweakwcs_example.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example of Running `tweakwcs` to Align JWST images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## About this Notebook\n",
+    "**Author:** Mihai Cara, STScI\n",
+    "<br>**Updated On:** 09/11/2018"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "from os import path\n",
+    "\n",
+    "import numpy as np\n",
+    "from astropy.table import Column, Table\n",
+    "from astropy.modeling.models import RotateNative2Celestial\n",
+    "\n",
+    "from jwst.datamodels import ImageModel\n",
+    "from tweakwcs import tweak_image_wcs, tweak_wcs, TPMatch, JWSTgWCS\n",
+    "from photutils import detect_threshold, DAOStarFinder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## Load Data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = '/Users/mcara/repo/tweakwcs/devdata/data' # replace with actual path to data\n",
+    "\n",
+    "# Load JWST image models:\n",
+    "im1 = ImageModel(path.join(data_dir, 'jw10002001001_01101_00001_nrcb1_cal.fits'))\n",
+    "im2 = ImageModel(path.join(data_dir, 'jw10002001001_01102_00001_nrcb1_cal.fits'))\n",
+    "\n",
+    "# save a copy of im1's wcs for later use in EXAMPLE 2:\n",
+    "im1_gwcs = deepcopy(im1.meta.wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## EXAMPLE 1: Typical Workflow to Align Two or More Images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Create Source Catalogs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for catno, im in enumerate([im1, im2]):\n",
+    "    threshold = detect_threshold(im.data, snr=5.0)[0, 0]\n",
+    "    daofind = DAOStarFinder(fwhm=2.5, threshold=threshold)\n",
+    "    cat = daofind(im.data)\n",
+    "    cat.rename_column('xcentroid', 'x')\n",
+    "    cat.rename_column('ycentroid', 'y')\n",
+    "    cat.meta['name'] = 'im{:d} sources'.format(catno)\n",
+    "    im.meta['catalog'] = cat\n",
+    "    # Assign group_id when aligning images that belong to the same SCA:\n",
+    "    # im.meta['group_id'] = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Align Images Using Image Source Catalogs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_image_wcs([im1, im2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Inspect Corrected WCS. Save Aligned Image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inspect WCS Tangent-Plane Corrections\n",
+    "for f, p in im2.meta.wcs.pipeline:\n",
+    "    if f == 'v2v3':\n",
+    "        print(p.__repr__())\n",
+    "        break\n",
+    "\n",
+    "# save the file:\n",
+    "im2.write('im2_aligned.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "## A Customizable Workflow to Align Two Simulated Catalogs\n",
+    "\n",
+    "In this example we assume that an image WCS contains errors by generating an image catalog artificially displaced with regard to a perfect reference catalog (obtained using this uncorrected/initial image WCS). We then use `tweakwcs` to find corrections to the image WCS to make the catalogs align."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Generate Reference Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ny, nx = im1.data.shape\n",
+    "\n",
+    "# generate random sources in im1 detector:\n",
+    "rcx = Column(data=np.random.randint(0, nx, 30), name='x', dtype=np.float)\n",
+    "rcy = Column(data=np.random.randint(0, ny, 30), name='y', dtype=np.float)\n",
+    "\n",
+    "# convert image coordinates to sky coords:\n",
+    "ra, dec = im1_gwcs(rcx, rcy)\n",
+    "rra = Column(data=ra, name='RA', dtype=np.float)\n",
+    "rdec = Column(data=dec, name='DEC', dtype=np.float)\n",
+    "\n",
+    "# create the catalog:\n",
+    "refcat = Table([rra, rdec])\n",
+    "refcat.meta['name'] = 'REFCAT'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Create Image Catalog\n",
+    "\n",
+    "We take the reference catalog and apply small Euler rotations to sky positions. This \"displaced\" catalog now will serve as an image catalog that we will try to align back to the reference catalog and find the correction that needs to be applied to the \"image's WCS\" to make image catalog align to the reference catalog. Essentially, here we simulate an image source catalog as if these sources were detected in image `im2` having the WCS from `im1.meta.wcs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply small Euler rotations to the reference source coordinates:\n",
+    "m = RotateNative2Celestial(5.0e-05, 90, 180)\n",
+    "ra_displ, dec_displ = m(ra, dec)\n",
+    "\n",
+    "# convert sky coordinates to image coordinates using initial/reference image WCS:\n",
+    "x_displ, y_displ = im1_gwcs.invert(ra_displ, dec_displ)\n",
+    "\n",
+    "# remove sources outside the detector:\n",
+    "mask = (x_displ > 0) & (x_displ < nx) & (y_displ > 0) & (y_displ < ny)\n",
+    "x_displ = x_displ[mask]\n",
+    "y_displ = y_displ[mask]\n",
+    "\n",
+    "# Create image catalog also randomizing source order:\n",
+    "imcat = Table([x_displ, y_displ], names=['x', 'y'])\n",
+    "imcat.meta['name'] = 'IMCAT'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Create a telescope/instrument-specific \"corrector\" WCS object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create JWST-specific TPWCS object using the WCS that needs to be corrected:\n",
+    "wcsinfo = im1.meta.wcsinfo._instance\n",
+    "imwcs = JWSTgWCS(wcs=im1_gwcs, wcsinfo=wcsinfo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Find Indices of Matched Sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Match sources in the catalogs:\n",
+    "match = TPMatch(searchrad=5, separation=0.1, tolerance=5, use2dhist=False)\n",
+    "ridx, iidx = match(refcat, imcat, imwcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Align Images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweaked_tpwcs = tweak_wcs(refcat[ridx], imcat[iidx], imwcs)\n",
+    "corrected_wcs = tweaked_tpwcs.wcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6. Inspect Corrected WCS. Save Aligned Image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# inspect WCS Tangent-Plane Corrections\n",
+    "for f, p in corrected_wcs.pipeline:\n",
+    "    if f == 'v2v3':\n",
+    "        print(p.__repr__())\n",
+    "        break\n",
+    "\n",
+    "# assign tweaked WCS as model's WCS:\n",
+    "im2.meta.wcs = corrected_wcs\n",
+    "\n",
+    "# save the file:\n",
+    "im2.write('im2_aligned.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebooks illustrates how to use `tweakwcs` to align JWST images. It contains two examples: i) basic/typical alignment of JWST images, and ii) custom workflow using simulated catalogs that allows customization of catalog matching and WCS alignment.

CC: @hcferguson @larrybradley @eteq 